### PR TITLE
Add/quotation frontend

### DIFF
--- a/device-portal-web/src/App.vue
+++ b/device-portal-web/src/App.vue
@@ -7,9 +7,10 @@ import { RouterView } from 'vue-router'
     <header class="app-header">
       <div class="container">
         <h1 class="app-title">Viadex Device Portal</h1>
-        <nav class="app-nav">
+                <nav class="app-nav">
           <RouterLink to="/devices" class="nav-link">Devices</RouterLink>
           <RouterLink to="/shipments" class="nav-link">Shipments</RouterLink>
+          <RouterLink to="/quotes" class="nav-link">Quote Calculator</RouterLink>
         </nav>
       </div>
     </header>

--- a/device-portal-web/src/assets/styles/status-badges.css
+++ b/device-portal-web/src/assets/styles/status-badges.css
@@ -75,17 +75,20 @@
 }
 
 /* Support Tier Badges */
-.tier-basic {
-  background-color: var(--color-gray-100);
-  color: var(--color-gray-700);
+.tier-basic,
+.status-basic {
+  background-color: var(--color-success-50);
+  color: var(--color-success-700);
 }
 
-.tier-standard {
+.tier-standard,
+.status-standard {
   background-color: var(--color-primary-50);
   color: var(--color-primary-700);
 }
 
-.tier-premium {
+.tier-premium,
+.status-premium {
   background-color: var(--color-warning-50);
   color: var(--color-warning-700);
 }

--- a/device-portal-web/src/components/QuoteCalculator.vue
+++ b/device-portal-web/src/components/QuoteCalculator.vue
@@ -244,10 +244,11 @@ const formatDate = (dateString: string) => {
 
 // Initialize on mount
 onMounted(async () => {
-  // Load devices if not already loaded
-  if (!devicesStore.hasDevices) {
-    await devicesStore.fetchDevices();
-  }
+  // Load all devices for quote calculator (temporarily set large page size)
+  const originalPageSize = devicesStore.filters.pageSize;
+  devicesStore.filters.pageSize = 100; // Set large page size to get all devices
+  await devicesStore.fetchDevices();
+  devicesStore.filters.pageSize = originalPageSize; // Restore original page size
 });
 </script>
 

--- a/device-portal-web/src/components/QuoteCalculator.vue
+++ b/device-portal-web/src/components/QuoteCalculator.vue
@@ -1,0 +1,476 @@
+<template>
+  <div class="quote-calculator">
+    <div class="calculator-header">
+      <h2>Quote Calculator</h2>
+      <p>Calculate leasing quotes for devices with support tiers</p>
+    </div>
+
+    <!-- Quote Calculation Form -->
+    <form @submit.prevent="calculateQuote" class="quote-form">
+      <div class="form-row">
+        <div class="form-group">
+          <label for="device" class="form-label">Device *</label>
+          <select
+            id="device"
+            v-model="form.deviceId"
+            :disabled="devicesLoading"
+            class="form-input"
+            required
+          >
+            <option value="">{{ devicesLoading ? 'Loading devices...' : 'Select a device' }}</option>
+            <option
+              v-for="device in availableDevices"
+              :key="device.id"
+              :value="device.id"
+            >
+              {{ device.name }} - {{ device.model }} (£{{ device.monthlyPrice }}/month)
+            </option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="customer" class="form-label">Customer Name *</label>
+          <input
+            id="customer"
+            v-model="form.customerName"
+            type="text"
+            placeholder="Enter customer name"
+            class="form-input"
+            required
+          />
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group">
+          <label for="duration" class="form-label">Lease Duration *</label>
+          <select
+            id="duration"
+            v-model="form.durationMonths"
+            class="form-input"
+            required
+          >
+            <option value="">Select duration</option>
+            <option
+              v-for="option in durationOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="support" class="form-label">Support Tier *</label>
+          <select
+            id="support"
+            v-model="form.supportTier"
+            class="form-input"
+            required
+          >
+            <option value="">Select support tier</option>
+            <option
+              v-for="tier in supportTierOptions"
+              :key="tier.value"
+              :value="tier.value"
+            >
+              {{ tier.label }} - {{ tier.description }}
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <div class="form-actions">
+        <button
+          type="submit"
+          :disabled="quoteStore.calculationLoading || !isFormValid"
+          class="btn btn-primary"
+        >
+          {{ quoteStore.calculationLoading ? 'Calculating...' : 'Calculate Quote' }}
+        </button>
+        <button
+          type="button"
+          @click="clearForm"
+          class="btn btn-secondary"
+        >
+          Clear Form
+        </button>
+      </div>
+    </form>
+
+    <!-- Calculation Error -->
+    <div v-if="quoteStore.calculationError" class="error-message">
+      <p>{{ quoteStore.calculationError }}</p>
+    </div>
+
+    <!-- Quote Result -->
+    <div v-if="quoteStore.calculatedQuote" class="quote-result">
+      <div class="result-header">
+        <h3>Quote Calculation Result</h3>
+        <button @click="quoteStore.clearCalculatedQuote()" class="close-btn">×</button>
+      </div>
+
+      <div class="result-content">
+        <div class="result-section">
+          <h4>Customer & Device Details</h4>
+          <div class="detail-grid">
+            <div class="detail-item">
+              <span class="detail-label">Customer:</span>
+              <span class="detail-value">{{ quoteStore.calculatedQuote.customerName }}</span>
+            </div>
+            <div class="detail-item">
+              <span class="detail-label">Device:</span>
+              <span class="detail-value">{{ quoteStore.calculatedQuote.deviceName }} - {{ quoteStore.calculatedQuote.deviceModel }}</span>
+            </div>
+            <div class="detail-item">
+              <span class="detail-label">Duration:</span>
+              <span class="detail-value">{{ quoteStore.calculatedQuote.durationMonths }} months</span>
+            </div>
+            <div class="detail-item">
+              <span class="detail-label">Support Tier:</span>
+              <span class="detail-value">{{ quoteStore.calculatedQuote.supportTierName }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="result-section">
+          <h4>Pricing Breakdown</h4>
+          <div class="pricing-grid">
+            <div class="pricing-item">
+              <span class="pricing-label">Base Monthly Rate:</span>
+              <span class="pricing-value">£{{ quoteStore.calculatedQuote.monthlyRate.toFixed(2) }}</span>
+            </div>
+            <div class="pricing-item">
+              <span class="pricing-label">Support Rate:</span>
+              <span class="pricing-value">£{{ quoteStore.calculatedQuote.supportRate.toFixed(2) }}</span>
+            </div>
+            <div class="pricing-item total">
+              <span class="pricing-label">Total Monthly Cost:</span>
+              <span class="pricing-value">£{{ quoteStore.calculatedQuote.totalMonthlyCost.toFixed(2) }}</span>
+            </div>
+            <div class="pricing-item final-total">
+              <span class="pricing-label">Total Lease Cost:</span>
+              <span class="pricing-value">£{{ quoteStore.calculatedQuote.totalCost.toFixed(2) }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="result-section">
+          <h4>Quote Validity</h4>
+          <p class="validity-info">
+            This quote is valid until: {{ formatDate(quoteStore.calculatedQuote.validUntil) }}
+          </p>
+        </div>
+      </div>
+
+      <div class="result-actions">
+        <button
+          @click="quoteStore.clearCalculatedQuote()"
+          class="btn btn-primary"
+        >
+          Calculate Another
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, computed, onMounted } from 'vue';
+import { useQuoteCalculatorStore } from '@/stores/useQuotes';
+import { useDevicesStore } from '@/stores/useDevices';
+import type { QuoteCalculateRequest } from '@/types/quote';
+import { DURATION_OPTIONS } from '@/types/quote';
+
+// Store initialization
+const quoteStore = useQuoteCalculatorStore();
+const devicesStore = useDevicesStore();
+
+// Form state
+const form = reactive<QuoteCalculateRequest>({
+  deviceId: 0,
+  customerName: '',
+  durationMonths: 0,
+  supportTier: 0
+});
+
+// Configuration options
+const durationOptions = DURATION_OPTIONS;
+
+const supportTierOptions = [
+  { value: 1, label: 'Basic', description: '+0% support' },
+  { value: 2, label: 'Standard', description: '+20% support' },
+  { value: 3, label: 'Premium', description: '+50% support' }
+];
+
+// Computed properties
+const devicesLoading = computed(() => devicesStore.loading);
+
+const availableDevices = computed(() =>
+  devicesStore.devices.filter(device => device.status === 1) // Only active devices
+);
+
+const isFormValid = computed(() =>
+  form.deviceId > 0 &&
+  form.customerName.trim() !== '' &&
+  form.durationMonths > 0 &&
+  form.supportTier > 0
+);
+
+// Methods
+const calculateQuote = async () => {
+  if (!isFormValid.value) return;
+
+  await quoteStore.calculateQuote({
+    deviceId: form.deviceId,
+    customerName: form.customerName.trim(),
+    durationMonths: form.durationMonths,
+    supportTier: form.supportTier
+  });
+};
+
+const clearForm = () => {
+  form.deviceId = 0;
+  form.customerName = '';
+  form.durationMonths = 0;
+  form.supportTier = 0;
+  quoteStore.clearCalculatedQuote();
+};
+
+const formatDate = (dateString: string) => {
+  return new Date(dateString).toLocaleDateString('en-GB');
+};
+
+// Initialize on mount
+onMounted(async () => {
+  // Load devices if not already loaded
+  if (!devicesStore.hasDevices) {
+    await devicesStore.fetchDevices();
+  }
+});
+</script>
+
+<style scoped>
+.quote-calculator {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.calculator-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.calculator-header h2 {
+  color: #1f2937;
+  margin-bottom: 0.5rem;
+}
+
+.calculator-header p {
+  color: #6b7280;
+}
+
+.quote-form {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  margin-bottom: 2rem;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-label {
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 0.5rem;
+}
+
+.form-input {
+  padding: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 1rem;
+  transition: border-color 0.2s;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+.quote-result {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.result-header {
+  background: #f8fafc;
+  padding: 1.5rem;
+  border-bottom: 1px solid #e5e7eb;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.result-header h3 {
+  margin: 0;
+  color: #1f2937;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: #6b7280;
+  padding: 0;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.close-btn:hover {
+  background: #e5e7eb;
+}
+
+.result-content {
+  padding: 2rem;
+}
+
+.result-section {
+  margin-bottom: 2rem;
+}
+
+.result-section:last-child {
+  margin-bottom: 0;
+}
+
+.result-section h4 {
+  color: #1f2937;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+}
+
+.detail-grid,
+.pricing-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.detail-item,
+.pricing-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.detail-label,
+.pricing-label {
+  font-weight: 500;
+  color: #6b7280;
+}
+
+.detail-value,
+.pricing-value {
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.pricing-item.total {
+  background: #f8fafc;
+  padding: 0.75rem;
+  border-radius: 6px;
+  border: none;
+  margin-top: 0.5rem;
+}
+
+.pricing-item.final-total {
+  background: #dbeafe;
+  border: 2px solid #3b82f6;
+  font-size: 1.1rem;
+}
+
+.pricing-item.final-total .pricing-value {
+  color: #1e40af;
+  font-size: 1.2rem;
+}
+
+.validity-info {
+  background: #fef3c7;
+  padding: 1rem;
+  border-radius: 6px;
+  color: #92400e;
+  margin: 0;
+}
+
+.result-actions {
+  padding: 1.5rem 2rem;
+  background: #f8fafc;
+  border-top: 1px solid #e5e7eb;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.error-message {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #dc2626;
+  padding: 1rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 768px) {
+  .quote-calculator {
+    padding: 1rem;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .form-actions,
+  .result-actions {
+    flex-direction: column;
+  }
+
+  .result-header {
+    padding: 1rem;
+  }
+
+  .result-content {
+    padding: 1rem;
+  }
+}
+</style>

--- a/device-portal-web/src/router/index.ts
+++ b/device-portal-web/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Devices from '@/views/Devices.vue'
 import Shipments from '@/views/Shipments.vue'
+import QuoteCalculator from '@/views/QuoteCalculator.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -19,6 +20,11 @@ const router = createRouter({
       path: '/shipments',
       name: 'shipments',
       component: Shipments
+    },
+    {
+      path: '/quotes',
+      name: 'quotes',
+      component: QuoteCalculator
     }
   ],
 })

--- a/device-portal-web/src/services/quoteApi.ts
+++ b/device-portal-web/src/services/quoteApi.ts
@@ -1,0 +1,19 @@
+// Quote API service for quote calculation only
+import api from './api';
+import type {
+  QuoteCalculation,
+  QuoteCalculateRequest
+} from '@/types/quote';
+
+export const quoteApi = {
+  // Calculate quote (without saving)
+  async calculateQuote(request: QuoteCalculateRequest): Promise<QuoteCalculation | null> {
+    try {
+      const response = await api.post<QuoteCalculation>('/api/quotes/calculate', request);
+      return response.data;
+    } catch (error) {
+      console.error('Error calculating quote:', error);
+      return null;
+    }
+  }
+};

--- a/device-portal-web/src/stores/useQuotes.ts
+++ b/device-portal-web/src/stores/useQuotes.ts
@@ -1,0 +1,55 @@
+// Simplified quote store for quote calculation only
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { quoteApi } from '@/services/quoteApi';
+import type {
+  QuoteCalculation,
+  QuoteCalculateRequest
+} from '@/types/quote';
+
+export const useQuoteCalculatorStore = defineStore('quoteCalculator', () => {
+  // Quote calculation state
+  const calculatedQuote = ref<QuoteCalculation | null>(null);
+  const calculationLoading = ref(false);
+  const calculationError = ref<string | null>(null);
+
+  // Actions
+  const calculateQuote = async (request: QuoteCalculateRequest) => {
+    calculationLoading.value = true;
+    calculationError.value = null;
+    calculatedQuote.value = null;
+
+    try {
+      const quote = await quoteApi.calculateQuote(request);
+      if (quote) {
+        calculatedQuote.value = quote;
+        return { success: true, quote };
+      } else {
+        throw new Error('Failed to calculate quote');
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to calculate quote';
+      calculationError.value = errorMessage;
+      console.error('Error calculating quote:', errorMessage);
+      return { success: false, error: errorMessage };
+    } finally {
+      calculationLoading.value = false;
+    }
+  };
+
+  const clearCalculatedQuote = () => {
+    calculatedQuote.value = null;
+    calculationError.value = null;
+  };
+
+  return {
+    // State
+    calculatedQuote,
+    calculationLoading,
+    calculationError,
+
+    // Actions
+    calculateQuote,
+    clearCalculatedQuote
+  };
+});

--- a/device-portal-web/src/types/quote.ts
+++ b/device-portal-web/src/types/quote.ts
@@ -1,0 +1,55 @@
+// TypeScript interfaces for Quote calculation functionality
+
+export interface QuoteCalculation {
+  deviceId: number;
+  deviceName: string;
+  deviceModel: string;
+  customerName: string;
+  durationMonths: number;
+  supportTier: number;
+  supportTierName: string;
+  monthlyRate: number;
+  supportRate: number;
+  totalMonthlyCost: number;
+  totalCost: number;
+  validUntil: string;
+}
+
+export interface QuoteCalculateRequest {
+  deviceId: number;
+  customerName: string;
+  durationMonths: number;
+  supportTier: number;
+}
+
+export enum SupportTier {
+  Basic = 1,
+  Standard = 2,
+  Premium = 3
+}
+
+export const SUPPORT_TIER_LABELS: Record<number, string> = {
+  [SupportTier.Basic]: 'Basic',
+  [SupportTier.Standard]: 'Standard',
+  [SupportTier.Premium]: 'Premium'
+};
+
+export const SUPPORT_TIER_COLORS: Record<number, string> = {
+  [SupportTier.Basic]: '#10b981',    // Green
+  [SupportTier.Standard]: '#3b82f6', // Blue
+  [SupportTier.Premium]: '#f59e0b'   // Orange
+};
+
+export const SUPPORT_TIER_DESCRIPTIONS: Record<number, string> = {
+  [SupportTier.Basic]: 'Basic support (+0%)',
+  [SupportTier.Standard]: 'Standard support (+20%)',
+  [SupportTier.Premium]: 'Premium support (+50%)'
+};
+
+export const DURATION_OPTIONS = [
+  { value: 6, label: '6 months' },
+  { value: 12, label: '12 months' },
+  { value: 18, label: '18 months' },
+  { value: 24, label: '24 months' },
+  { value: 36, label: '36 months' }
+];

--- a/device-portal-web/src/views/QuoteCalculator.vue
+++ b/device-portal-web/src/views/QuoteCalculator.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="page-view">
+    <div class="page-header">
+      <h1>Quote Calculator</h1>
+      <p>Calculate leasing quotes for devices with different support tiers</p>
+    </div>
+
+    <QuoteCalculatorComponent />
+  </div>
+</template>
+
+<script setup lang="ts">
+import QuoteCalculatorComponent from '@/components/QuoteCalculator.vue';
+</script>
+
+<style scoped>
+.page-view {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.page-header {
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.page-header h1 {
+  font-size: 2.5rem;
+  color: #1f2937;
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  color: #6b7280;
+  font-size: 1.1rem;
+}
+</style>


### PR DESCRIPTION
This pull request introduces a new Quote Calculator feature to the device portal web application, allowing users to calculate leasing quotes for devices with different support tiers. The implementation includes a new route and view, supporting TypeScript types, a store for quote calculation state, and a dedicated API service. Additionally, UI improvements were made to support tier badges for better consistency.

**Quote Calculator Feature:**

* Added a new `/quotes` route and navigation link for the Quote Calculator, including the `QuoteCalculator` view and component registration (`device-portal-web/src/router/index.ts`, `device-portal-web/src/App.vue`, `device-portal-web/src/views/QuoteCalculator.vue`). [[1]](diffhunk://#diff-bb04b2890c02e2198a791cc05cac0063fa0c761dd66bbe409bf79bc7f2bd3006R4) [[2]](diffhunk://#diff-bb04b2890c02e2198a791cc05cac0063fa0c761dd66bbe409bf79bc7f2bd3006R23-R27) [[3]](diffhunk://#diff-2c1265e5a4860ede5f5a54349d37d2567607da2ec350c7882a1346d5b1a048efR13) [[4]](diffhunk://#diff-2686611abe9cf6aa52a61d918c2400d8da2840ba5a6c97c7ca53ee120186674bR1-R38)
* Implemented a new Pinia store, `useQuoteCalculatorStore`, to manage quote calculation state and actions, including error handling and loading state (`device-portal-web/src/stores/useQuotes.ts`).
* Created a dedicated API service, `quoteApi`, for calculating quotes via the backend (`device-portal-web/src/services/quoteApi.ts`).
* Defined TypeScript interfaces and enums for quote calculation, support tiers, and duration options to ensure type safety and maintainability (`device-portal-web/src/types/quote.ts`).

**UI Consistency:**

* Updated support tier badge styles to use consistent color schemes and allow both `.tier-*` and `.status-*` classes for improved UI consistency (`device-portal-web/src/assets/styles/status-badges.css`).